### PR TITLE
Add deprecation notice for Python MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Telnyx Local Model Context Protocol (MCP) Server
 
+> **⚠️ DEPRECATED**: This Python-based MCP server is deprecated. Please migrate to the official TypeScript version:
+>
+> **New Repository:** https://github.com/team-telnyx/telnyx-node/tree/main/packages/mcp-server
+
+---
+
 Official Telnyx Local Model Context Protocol (MCP) Server that enables interaction with powerful telephony, messaging, and AI assistant APIs. This server allows MCP clients like Claude Desktop, Cursor, Windsurf, OpenAI Agents and others to manage phone numbers, send messages, make calls, and create AI assistants.
 
 ## Quickstart with Claude Desktop


### PR DESCRIPTION
## Summary
- Adds deprecation notice at the top of README
- Links to the new official TypeScript MCP server in telnyx-node repository
- Prepares for archiving this repository

## Context
The Python-based MCP server is being deprecated in favor of the auto-generated TypeScript version maintained in the telnyx-node repository. The new version provides better maintenance and stays up-to-date with the Telnyx API.

## Next Steps
After merging:
1. Set repository archive date (suggest 3-6 months)
2. Create final release with deprecation warning
3. Archive repository after grace period

🤖 Generated with [Claude Code](https://claude.com/claude-code)